### PR TITLE
Apply ocean blue gradient across portfolio sections

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -40,11 +40,14 @@ export default function ContactSection() {
   };
 
   return (
-    <section id="contact" className="py-20 bg-slate-50">
+    <section
+      id="contact"
+      className="py-20 bg-gradient-to-b from-blue-600 via-blue-500 to-blue-400"
+    >
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-slate-800 mb-4">Wanna Reach Out?</h2>
-          <p className="text-xl text-slate-600">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Wanna Reach Out?</h2>
+          <p className="text-xl text-blue-100">
             Let's connect! Whether you have a question, want to collaborate, or just say hi, feel free to reach out through any of the methods below.
           </p>
         </div>
@@ -58,8 +61,8 @@ export default function ContactSection() {
                   <div className="bg-primary/10 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                     <IconComponent className="h-6 w-6 text-primary" />
                   </div>
-                  <h3 className="font-bold text-white mb-2">{method.title}</h3>
-                  <p className="text-slate-600 mb-4">{method.value}</p>
+                  <h3 className="font-bold text-blue-100 mb-2">{method.title}</h3>
+                  <p className="text-blue-100 mb-4">{method.value}</p>
                   <a 
                     href={method.link} 
                     className="text-primary hover:text-primary/80 font-medium transition-colors"

--- a/src/components/education-section.tsx
+++ b/src/components/education-section.tsx
@@ -31,18 +31,21 @@ const achievements = [
 
 export default function EducationSection() {
   return (
-    <section id="education" className="py-20 bg-gradient-to-br from-blue-50 to-white">
+    <section
+      id="education"
+      className="py-20 bg-gradient-to-b from-blue-700 via-blue-600 to-blue-500"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-slate-800 mb-4">Education</h2>
-          <p className="text-xl text-slate-600 max-w-2xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Education</h2>
+          <p className="text-xl text-slate-200 max-w-2xl mx-auto">
             Building a strong foundation in computer systems engineering and emerging technologies.
           </p>
         </div>
 
         <div className="grid lg:grid-cols-2 gap-8">
           {/* Current Education */}
-          <div className="bg-gradient-to-tr from-blue-400 to-blue-600 p-8 rounded-2xl text-white">
+          <div className="bg-gradient-to-tr from-blue-500 to-blue-700 p-8 rounded-2xl text-white">
             <div className="flex items-start space-x-4">
               <div className="bg-white/20 p-3 rounded-lg">
                 <GraduationCap className="h-6 w-6" />

--- a/src/components/experience-section.tsx
+++ b/src/components/experience-section.tsx
@@ -79,11 +79,14 @@ const experiences = [
 
 export default function ExperienceSection() {
   return (
-    <section id="experience" className="py-20 bg-blue-100">
+    <section
+      id="experience"
+      className="py-20 bg-gradient-to-b from-blue-800 via-blue-700 to-blue-600"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-black">PROFESSIONAL EXPERIENCE</h2>
-          <p className="text-xl text-slate-600 max-w-2xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold text-white">PROFESSIONAL EXPERIENCE</h2>
+          <p className="text-xl text-slate-200 max-w-2xl mx-auto">
             Building expertise through hands-on experience in software development, embedded systems, and machine learning.
           </p>
         </div>
@@ -105,7 +108,7 @@ export default function ExperienceSection() {
                     <CardContent className="p-6">
                       <div className="flex items-start justify-between mb-4">
                         <div>
-                          <h3 className="text-xl font-bold text-blue-400">{exp.title}</h3>
+                          <h3 className="text-xl font-bold text-blue-600">{exp.title}</h3>
                           <p className={`font-medium ${exp.current ? 'text-primary' : 'text-slate-600'}`}>
                             {exp.company}
                           </p>

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -23,28 +23,31 @@ export default function HeroSection() {
   };
 
   return (
-    <section id="home" className="pt-16 min-h-screen flex items-center bg-gradient-to-br from-black-100 via-black-100 to-black-100">
+    <section
+      id="home"
+      className="pt-16 min-h-screen flex items-center bg-gradient-to-b from-blue-900 via-blue-800 to-blue-700"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           <div className="space-y-8 animate-slide-up">
             <div className="space-y-4">
-              <h1 className="text-4xl md:text-6xl font-bold text-blue-400 leading-tight">
+              <h1 className="text-4xl md:text-6xl font-bold text-blue-300 leading-tight">
                 Computer
                 <span className="text-primary block">Engineering</span>
               </h1>
-              <p className="text-xl text-slate-600 leading-relaxed max-w-lg">
+              <p className="text-xl text-slate-100 leading-relaxed max-w-lg">
                 Passionate about building innovative solutions at the intersection of software, hardware, and artificial intelligence.
               </p>
             </div>
             
             <div className="flex flex-wrap gap-3">
-              <Badge variant="secondary" className="px-4 py-2 text-sm font-medium bg-blue-200 text-blue-900">
+              <Badge variant="secondary" className="px-4 py-2 text-sm font-medium bg-blue-500 text-white">
                 Software Development/Engineering
               </Badge>
-              <Badge variant="secondary" className="px-4 py-2 text-sm font-medium bg-blue-200 text-blue-900">
+              <Badge variant="secondary" className="px-4 py-2 text-sm font-medium bg-blue-500 text-white">
                 Embedded/Electronics Systems
               </Badge>
-              <Badge variant="secondary" className="px-4 py-2 text-sm font-medium bg-blue-200 text-blue-900">
+              <Badge variant="secondary" className="px-4 py-2 text-sm font-medium bg-blue-500 text-white">
                 Machine Learning/Generative-AI
               </Badge>
             </div>
@@ -67,13 +70,13 @@ export default function HeroSection() {
             </div>
 
             <div className="flex space-x-6">
-              <a href="https://www.linkedin.com/in/ybenpc/" className="text-slate-600 hover:text-primary transition-colors">
+              <a href="https://www.linkedin.com/in/ybenpc/" className="text-blue-300 hover:text-white transition-colors">
                 <SiLinkedin className="h-6 w-6" />
               </a>
-              <a href="https://www.github.com/YBenjaminPCondori" className="text-slate-600 hover:text-primary transition-colors">
+              <a href="https://www.github.com/YBenjaminPCondori" className="text-blue-300 hover:text-white transition-colors">
                 <SiGithub className="h-6 w-6" />
               </a>
-              <a href="mailto:y.benjamin@ybenpc.com" className="text-slate-600 hover:text-primary transition-colors">
+              <a href="mailto:y.benjamin@ybenpc.com" className="text-blue-300 hover:text-white transition-colors">
                 <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
                 </svg>

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -110,11 +110,16 @@ export default function ProjectsSection() {
       : projects.filter((project) => project.category === activeCategory);
 
   return (
-    <section id="projects" className="py-20 bg-blue-50">
+    <section
+      id="projects"
+      className="py-20 bg-gradient-to-b from-blue-700 via-blue-600 to-blue-500"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-slate-800 mb-4">Projects and Academic Work</h2>
-          <p className="text-xl text-slate-600 max-w-2xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+            Projects and Academic Work
+          </h2>
+          <p className="text-xl text-blue-100 max-w-2xl mx-auto">
             Projects in embedded systems, machine learning, edge AI, microcontrollers, and full-stack software.
           </p>
         </div>


### PR DESCRIPTION
## Summary
- give hero section dark blue gradient background
- update experience section to dark blue gradient
- apply dark blue gradient to education section
- update contact section with ocean blue gradient
- bring projects section into gradient sequence

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c14a1188324abd2c381c059c3c3