### PR TITLE
Change color scheme to black and blue

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -42,12 +42,12 @@ export default function ContactSection() {
   return (
     <section
       id="contact"
-      className="py-20 bg-gradient-to-b from-purple-700 via-purple-600 to-purple-500"
+      className="py-20 bg-black"
     >
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Wanna Reach Out?</h2>
-          <p className="text-xl text-purple-100">
+          <h2 className="text-3xl md:text-4xl font-bold text-blue-500 mb-4">Wanna Reach Out?</h2>
+          <p className="text-xl text-blue-500">
             Let's connect! Whether you have a question, want to collaborate, or just say hi, feel free to reach out through any of the methods below.
           </p>
         </div>
@@ -58,14 +58,14 @@ export default function ContactSection() {
             return (
               <Card key={index} className="text-center hover:shadow-xl transition-shadow">
                 <CardContent className="p-6">
-                  <div className="bg-primary/10 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <IconComponent className="h-6 w-6 text-primary" />
+                  <div className="bg-black w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <IconComponent className="h-6 w-6 text-blue-500" />
                   </div>
-              <h3 className="font-bold text-purple-100 mb-2">{method.title}</h3>
-                  <p className="text-purple-100 mb-4">{method.value}</p>
+              <h3 className="font-bold text-blue-500 mb-2">{method.title}</h3>
+                  <p className="text-blue-500 mb-4">{method.value}</p>
                   <a 
                     href={method.link} 
-                    className="text-primary hover:text-primary/80 font-medium transition-colors"
+                    className="text-blue-500 hover:text-blue-700 font-medium transition-colors"
                   >
                     {method.action}
                   </a>
@@ -79,7 +79,7 @@ export default function ContactSection() {
         <div className="text-center mt-12">
           <Button 
             onClick={handleDownloadResume}
-            className="bg-primary hover:bg-primary/90 text-white px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-200"
+            className="bg-black text-blue-500 px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-200"
           >
             <Download className="mr-2 h-5 w-5" />
             Download Full Resume

--- a/src/components/education-section.tsx
+++ b/src/components/education-section.tsx
@@ -33,35 +33,35 @@ export default function EducationSection() {
   return (
     <section
       id="education"
-      className="py-20 bg-gradient-to-b from-purple-700 via-purple-600 to-purple-500"
+      className="py-20 bg-black"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Education</h2>
-          <p className="text-xl text-slate-200 max-w-2xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold text-blue-500 mb-4">Education</h2>
+          <p className="text-xl text-blue-500 max-w-2xl mx-auto">
             Building a strong foundation in computer systems engineering and emerging technologies.
           </p>
         </div>
 
         <div className="grid lg:grid-cols-2 gap-8">
           {/* Current Education */}
-          <div className="bg-gradient-to-tr from-purple-500 to-purple-700 p-8 rounded-2xl text-white">
+          <div className="bg-black p-8 rounded-2xl text-blue-500">
             <div className="flex items-start space-x-4">
-              <div className="bg-white/20 p-3 rounded-lg">
+              <div className="bg-black p-3 rounded-lg">
                 <GraduationCap className="h-6 w-6" />
               </div>
               <div className="flex-1">
                 <h3 className="text-2xl font-bold mb-2">Bachelor of Engineering</h3>
-                <p className="text-purple-100 font-semibold text-lg mb-1">Computer Systems Engineering</p>
-                <p className="text-purple-200 mb-3">Brunel University of London</p>
-                <p className="text-sm text-purple-200 mb-4">Expected Graduation: July 2025</p>
+                <p className="text-blue-500 font-semibold text-lg mb-1">Computer Systems Engineering</p>
+                <p className="text-blue-500 mb-3">Brunel University of London</p>
+                <p className="text-sm text-blue-500 mb-4">Expected Graduation: July 2025</p>
                 
                 <div className="space-y-3">
                   <div>
                     <h4 className="font-semibold mb-2">Relevant Coursework:</h4>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                       {coursework.map((course) => (
-                        <span key={course} className="text-sm text-purple-100">• {course}</span>
+                        <span key={course} className="text-sm text-blue-500">• {course}</span>
                       ))}
                     </div>
                   </div>
@@ -73,11 +73,11 @@ export default function EducationSection() {
           {/* Skills & Certifications */}
           <div className="space-y-8">
             {/* Technical Skills */}
-            <Card className="bg-purple-50 border border-purple-100">
+            <Card className="bg-black border border-black">
               <CardContent className="p-8">
-                <h3 className="text-xl font-bold text-slate-800 mb-6 flex items-center">
-                  <div className="bg-primary/10 p-2 rounded-lg mr-3">
-                    <svg className="h-5 w-5 text-primary" fill="currentColor" viewBox="0 0 24 24">
+                <h3 className="text-xl font-bold text-blue-500 mb-6 flex items-center">
+                  <div className="bg-black p-2 rounded-lg mr-3">
+                    <svg className="h-5 w-5 text-blue-500" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/>
                     </svg>
                   </div>
@@ -85,7 +85,7 @@ export default function EducationSection() {
                 </h3>
                 <div className="space-y-4">
                   <div>
-                    <h4 className="font-semibold text-slate-700 mb-2">Programming Languages</h4>
+                    <h4 className="font-semibold text-blue-500 mb-2">Programming Languages</h4>
                     <div className="flex flex-wrap gap-2">
                       {skills.languages.map((lang) => (
                         <Badge key={lang} variant="secondary" className="text-sm">
@@ -95,7 +95,7 @@ export default function EducationSection() {
                     </div>
                   </div>
                   <div>
-                    <h4 className="font-semibold text-slate-700 mb-2">Frameworks & Tools</h4>
+                    <h4 className="font-semibold text-blue-500 mb-2">Frameworks & Tools</h4>
                     <div className="flex flex-wrap gap-2">
                       {skills.frameworks.map((framework) => (
                         <Badge key={framework} variant="secondary" className="text-sm">
@@ -109,19 +109,19 @@ export default function EducationSection() {
             </Card>
 
             {/* Certifications */}
-            <Card className="bg-purple-50 border border-purple-100">
+            <Card className="bg-black border border-black">
               <CardContent className="p-8">
-                <h3 className="text-xl font-bold text-slate-800 mb-6 flex items-center">
-                  <div className="bg-primary/10 p-2 rounded-lg mr-3">
-                    <Award className="h-5 w-5 text-primary" />
+                <h3 className="text-xl font-bold text-blue-500 mb-6 flex items-center">
+                  <div className="bg-black p-2 rounded-lg mr-3">
+                    <Award className="h-5 w-5 text-blue-500" />
                   </div>
                   Certifications
                 </h3>
                 <div className="space-y-3">
                   {certifications.map((cert) => (
                     <div key={cert.name} className="flex items-center justify-between">
-                      <span className="text-slate-700">{cert.name}</span>
-                      <span className="text-sm text-slate-500">{cert.year}</span>
+                      <span className="text-blue-500">{cert.name}</span>
+                      <span className="text-sm text-blue-500">{cert.year}</span>
                     </div>
                   ))}
                 </div>
@@ -132,19 +132,19 @@ export default function EducationSection() {
 
         {/* Achievements */}
         <div className="mt-12">
-          <Card className="bg-purple-50 border border-purple-200">
+          <Card className="bg-black border border-black">
             <CardContent className="p-8">
-              <h3 className="text-xl font-bold text-slate-800 mb-6 text-center">Achievements & Activities</h3>
+              <h3 className="text-xl font-bold text-blue-500 mb-6 text-center">Achievements & Activities</h3>
               <div className="grid md:grid-cols-3 gap-6">
                 {achievements.map((achievement, index) => {
                   const IconComponent = achievement.icon;
                   return (
                     <div key={index} className="text-center">
-                      <div className="bg-primary/10 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                        <IconComponent className="h-8 w-8 text-primary" />
+                      <div className="bg-black w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <IconComponent className="h-8 w-8 text-blue-500" />
                       </div>
-                      <h4 className="font-semibold text-slate-800 mb-1">{achievement.title}</h4>
-                      <p className="text-sm text-slate-600">{achievement.subtitle}</p>
+                      <h4 className="font-semibold text-blue-500 mb-1">{achievement.title}</h4>
+                      <p className="text-sm text-blue-500">{achievement.subtitle}</p>
                     </div>
                   );
                 })}

--- a/src/components/experience-section.tsx
+++ b/src/components/experience-section.tsx
@@ -80,12 +80,12 @@ export default function ExperienceSection() {
   return (
     <section
       id="experience"
-      className="py-20 bg-gradient-to-b from-purple-800 via-purple-700 to-purple-600"
+      className="py-20 bg-black"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-white">PROFESSIONAL EXPERIENCE</h2>
-          <p className="text-xl text-slate-200 max-w-2xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold text-blue-500">PROFESSIONAL EXPERIENCE</h2>
+          <p className="text-xl text-blue-500 max-w-2xl mx-auto">
             Building expertise through hands-on experience in software development, embedded systems, and machine learning.
           </p>
         </div>
@@ -98,17 +98,15 @@ export default function ExperienceSection() {
           <div className="space-y-12">
             {experiences.map((exp, index) => (
               <div key={exp.id} className={`relative flex items-center ${index % 2 === 1 ? 'md:flex-row-reverse' : ''}`}>
-                <div className={`absolute left-6 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg ${
-                  exp.current ? 'bg-primary' : 'bg-slate-400'
-                }`}></div>
+                <div className="absolute left-6 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg bg-black"></div>
                 
                 <div className={`ml-16 md:ml-0 md:w-1/2 ${index % 2 === 1 ? 'md:pl-12' : 'md:pr-12'}`}>
-                  <Card className="bg-white/90 hover:shadow-xl border border-purple-500 transition-shadow">
+                  <Card className="bg-black hover:shadow-xl border border-black transition-shadow">
                     <CardContent className="p-6">
                       <div className="flex items-start justify-between mb-4">
                         <div>
-                          <h3 className="text-xl font-bold text-black">{exp.title}</h3>
-                          <p className={`font-medium ${exp.current ? 'text-primary' : 'text-slate-600'}`}>
+                          <h3 className="text-xl font-bold text-blue-500">{exp.title}</h3>
+                          <p className="font-medium text-blue-500">
                             {exp.company}
                           </p>
                         </div>
@@ -117,7 +115,7 @@ export default function ExperienceSection() {
                   </Badge>
                 </div>
                       
-                      <p className="text-slate-600 mb-4">{exp.description}</p>
+                      <p className="text-blue-500 mb-4">{exp.description}</p>
                       
                       <div className="flex flex-wrap gap-2">
                         {exp.technologies.map((tech) => (

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -25,17 +25,17 @@ export default function HeroSection() {
   return (
     <section
       id="home"
-      className="pt-16 min-h-screen flex items-center bg-gradient-to-b from-purple-900 via-purple-800 to-purple-700"
+      className="pt-16 min-h-screen flex items-center bg-black"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           <div className="space-y-8 animate-slide-up">
             <div className="space-y-4">
-              <h1 className="text-4xl md:text-6xl font-bold text-blue-300 leading-tight">
+              <h1 className="text-4xl md:text-6xl font-bold text-blue-500 leading-tight">
                 Computer
-                <span className="text-primary block">Engineering</span>
+                <span className="text-blue-500 block">Engineering</span>
               </h1>
-              <p className="text-xl text-slate-100 leading-relaxed max-w-lg">
+              <p className="text-xl text-blue-500 leading-relaxed max-w-lg">
                 Passionate about building innovative solutions at the intersection of software, hardware, and artificial intelligence.
               </p>
             </div>
@@ -56,27 +56,27 @@ export default function HeroSection() {
               <Button
                 variant="outline" 
                 onClick={handleDownloadResume}
-                className="border-primary text-white hover:bg-primary hover:text-white font-semibold">
+                className="border-blue-500 text-blue-500 hover:bg-blue-700 hover:text-white font-semibold">
                 <Download className="mr-2 h-4 w-4 group-hover:animate-bounce" />
                 Download Resume
               </Button>
               <Button 
                 variant="outline" 
                 onClick={handleViewProjects}
-                className="border-primary text-white hover:bg-primary hover:text-white font-semibold">
+                className="border-blue-500 text-blue-500 hover:bg-blue-700 hover:text-white font-semibold">
                 View Projects
                 <ExternalLink className="ml-2 h-4 w-4" />
               </Button>
             </div>
 
             <div className="flex space-x-6">
-              <a href="https://www.linkedin.com/in/ybenpc/" className="text-teal-300 hover:text-white transition-colors">
+              <a href="https://www.linkedin.com/in/ybenpc/" className="text-blue-500 transition-colors">
                 <SiLinkedin className="h-6 w-6" />
               </a>
-              <a href="https://www.github.com/YBenjaminPCondori" className="text-teal-300 hover:text-white transition-colors">
+              <a href="https://www.github.com/YBenjaminPCondori" className="text-blue-500 transition-colors">
                 <SiGithub className="h-6 w-6" />
               </a>
-              <a href="mailto:y.benjamin@ybenpc.com" className="text-teal-300 hover:text-white transition-colors">
+              <a href="mailto:y.benjamin@ybenpc.com" className="text-blue-500 transition-colors">
                 <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
                 </svg>
@@ -85,7 +85,7 @@ export default function HeroSection() {
           </div>
 
           <div className="relative animate-fade-in">
-            <div className="bg-purple-100 rounded-2xl p-8">
+            <div className="bg-black rounded-2xl p-8">
               <img 
                 src="/img/CSE.png" 
                 alt="Professional engineer working on computer systems" 

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -114,14 +114,14 @@ export default function ProjectsSection() {
   return (
     <section
       id="projects"
-      className="py-20 bg-gradient-to-b from-purple-700 via-purple-600 to-purple-500"
+      className="py-20 bg-black"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+          <h2 className="text-3xl md:text-4xl font-bold text-blue-500 mb-4">
             Projects and Academic Work
           </h2>
-          <p className="text-xl text-purple-100 max-w-2xl mx-auto">
+          <p className="text-xl text-blue-500 max-w-2xl mx-auto">
             Projects in embedded systems, machine learning, edge AI, microcontrollers, and full-stack software.
           </p>
         </div>
@@ -145,7 +145,7 @@ export default function ProjectsSection() {
           {filteredProjects.map((project) => (
             <Card
               key={project.id}
-              className="bg-white/90 border border-purple-100 overflow-hidden hover:shadow-xl transition-all duration-300 project-card"
+              className="bg-black border border-black overflow-hidden hover:shadow-xl transition-all duration-300 project-card"
             >
               <div className="relative">
                 <img
@@ -156,18 +156,18 @@ export default function ProjectsSection() {
               </div>
               <CardContent className="p-6">
                 <div className="flex items-center justify-between mb-3">
-                  <h3 className="text-xl font-bold text-purple-700">{project.title}</h3>
+                  <h3 className="text-xl font-bold text-blue-500">{project.title}</h3>
                   <div className="flex space-x-2">
                     <a
                       href={project.githubUrl}
-                      className="text-slate-400 hover:text-primary transition-colors"
+                      className="text-blue-500 transition-colors"
                     >
                       <Github className="h-5 w-5" />
                     </a>
                     {project.liveUrl && (
                       <a
                         href={project.liveUrl}
-                        className="text-slate-400 hover:text-primary transition-colors"
+                        className="text-blue-500 transition-colors"
                       >
                         <ExternalLink className="h-5 w-5" />
                       </a>
@@ -175,7 +175,7 @@ export default function ProjectsSection() {
                   </div>
                 </div>
 
-                <p className="text-slate-600 mb-4 text-sm leading-relaxed">
+                <p className="text-blue-500 mb-4 text-sm leading-relaxed">
                   {project.description}
                 </p>
 

--- a/src/index.css
+++ b/src/index.css
@@ -4,22 +4,22 @@
 @tailwind utilities;
 
 :root {
-  --background: 0 0% 100%;
-  --foreground: 222 47% 11%;
+  --background: 0 0% 0%;
+  --foreground: 240 100% 50%;
   --muted: 210 40% 98%;
   --muted-foreground: 215 16% 47%;
   --popover: 0 0% 100%;
   --popover-foreground: 222 47% 11%;
   --card: 0 0% 100%;
   --card-foreground: 222 47% 11%;
-  --border: 214 32% 91%;
-  --input: 214 32% 91%;
-  --primary: 271 62% 52%;
-  --primary-foreground: 0 0% 100%;
-  --secondary: 210 40% 98%;
-  --secondary-foreground: 222 47% 11%;
-  --accent: 210 40% 98%;
-  --accent-foreground: 222 47% 11%;
+  --border: 0 0% 0%;
+  --input: 0 0% 0%;
+  --primary: 240 100% 50%;
+  --primary-foreground: 0 0% 0%;
+  --secondary: 0 0% 0%;
+  --secondary-foreground: 240 100% 50%;
+  --accent: 0 0% 0%;
+  --accent-foreground: 240 100% 50%;
   --destructive: 0 84% 60%;
   --destructive-foreground: 210 40% 98%;
   --ring: 271 62% 52%;
@@ -32,28 +32,28 @@
 }
 
 .dark {
-  --background: 224 71% 4%;
-  --foreground: 213 31% 91%;
-  --muted: 223 47% 11%;
-  --muted-foreground: 215 16% 57%;
-  --popover: 224 71% 4%;
-  --popover-foreground: 213 31% 91%;
-  --card: 224 71% 4%;
-  --card-foreground: 213 31% 91%;
-  --border: 216 34% 17%;
-  --input: 216 34% 17%;
-  --primary: 271 62% 52%;
-  --primary-foreground: 0 0% 100%;
-  --accent: 216 34% 17%;
-  --accent-foreground: 213 31% 91%;
-  --destructive: 0 63% 31%;
-  --destructive-foreground: 213 31% 91%;
-  --ring: 271 62% 52%;
-  --chart-1: 271 62% 52%;
-  --chart-2: 192 70% 52%;
-  --chart-3: 216 92% 60%;
-  --chart-4: 210 98% 78%;
-  --chart-5: 212 97% 87%;
+  --background: 0 0% 0%;
+  --foreground: 240 100% 50%;
+  --muted: 0 0% 0%;
+  --muted-foreground: 240 100% 50%;
+  --popover: 0 0% 0%;
+  --popover-foreground: 240 100% 50%;
+  --card: 0 0% 0%;
+  --card-foreground: 240 100% 50%;
+  --border: 0 0% 0%;
+  --input: 0 0% 0%;
+  --primary: 240 100% 50%;
+  --primary-foreground: 0 0% 0%;
+  --accent: 0 0% 0%;
+  --accent-foreground: 240 100% 50%;
+  --destructive: 0 0% 0%;
+  --destructive-foreground: 240 100% 50%;
+  --ring: 240 100% 50%;
+  --chart-1: 240 100% 50%;
+  --chart-2: 240 100% 50%;
+  --chart-3: 240 100% 50%;
+  --chart-4: 240 100% 50%;
+  --chart-5: 240 100% 50%;
 }
 
 @layer base {
@@ -120,17 +120,18 @@
 }
 
 /* Gradient backgrounds */
+
 .bg-gradient-primary {
-  background: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(209, 94%, 13%) 100%);
+  background: black;
 }
 
 .bg-gradient-light {
-  background: linear-gradient(135deg, hsl(var(--muted)) 0%, hsl(210, 93%, 16%) 100%);
+  background: black;
 }
 
 /* Timeline styles */
 .timeline-line {
-  background: linear-gradient(to bottom, hsl(var(--primary)), hsl(var(--primary) / 0.3));
+  background: black;
 }
 
 /* Project card hover effects */

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -16,9 +16,9 @@ export default function Home() {
         <EducationSection />
         <ContactSection />
       </main>
-      <footer className="bg-slate-900 text-white py-8">
+      <footer className="bg-black text-blue-500 py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-slate-400">&copy; Website Developed by Y. Benjamin Perez C. ©</p>
+          <p className="text-blue-500">&copy; Website Developed by Y. Benjamin Perez C. ©</p>
         </div>
       </footer>
     </div>

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -3,15 +3,15 @@ import { AlertCircle } from "lucide-react";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen w-full flex items-center justify-center bg-black">
       <Card className="w-full max-w-md mx-4">
         <CardContent className="pt-6">
           <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+            <AlertCircle className="h-8 w-8 text-blue-500" />
+            <h1 className="text-2xl font-bold text-blue-500">404 Page Not Found</h1>
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
+          <p className="mt-4 text-sm text-blue-500">
             Did you forget to add the page to the router?
           </p>
         </CardContent>


### PR DESCRIPTION
## Summary
- set global background variables to black and foreground to blue
- remove gradients and set components to use blue text
- update footer and pages to follow new colour scheme

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844da3949b8832498cf300d2ac89d44