### PR TITLE
Update section backgrounds to light blue

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -42,7 +42,7 @@ export default function ContactSection() {
   return (
     <section
       id="contact"
-      className="py-20 bg-black"
+      className="py-20 bg-sky-50"
     >
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
@@ -58,7 +58,7 @@ export default function ContactSection() {
             return (
               <Card key={index} className="text-center hover:shadow-xl transition-shadow">
                 <CardContent className="p-6">
-                  <div className="bg-black w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <div className="bg-sky-200 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                     <IconComponent className="h-6 w-6 text-blue-500" />
                   </div>
               <h3 className="font-bold text-blue-500 mb-2">{method.title}</h3>
@@ -77,9 +77,9 @@ export default function ContactSection() {
 
         {/* Download Resume CTA */}
         <div className="text-center mt-12">
-          <Button 
+          <Button
             onClick={handleDownloadResume}
-            className="bg-black text-blue-500 px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-200"
+            className="bg-sky-200 text-blue-500 px-8 py-4 text-lg font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-200"
           >
             <Download className="mr-2 h-5 w-5" />
             Download Full Resume

--- a/src/components/education-section.tsx
+++ b/src/components/education-section.tsx
@@ -33,7 +33,7 @@ export default function EducationSection() {
   return (
     <section
       id="education"
-      className="py-20 bg-black"
+      className="py-20 bg-sky-50"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
@@ -45,9 +45,9 @@ export default function EducationSection() {
 
         <div className="grid lg:grid-cols-2 gap-8">
           {/* Current Education */}
-          <div className="bg-black p-8 rounded-2xl text-blue-500">
+          <div className="bg-sky-100 p-8 rounded-2xl text-blue-500">
             <div className="flex items-start space-x-4">
-              <div className="bg-black p-3 rounded-lg">
+              <div className="bg-sky-200 p-3 rounded-lg">
                 <GraduationCap className="h-6 w-6" />
               </div>
               <div className="flex-1">
@@ -73,10 +73,10 @@ export default function EducationSection() {
           {/* Skills & Certifications */}
           <div className="space-y-8">
             {/* Technical Skills */}
-            <Card className="bg-black border border-black">
+            <Card className="bg-sky-100 border border-sky-200">
               <CardContent className="p-8">
                 <h3 className="text-xl font-bold text-blue-500 mb-6 flex items-center">
-                  <div className="bg-black p-2 rounded-lg mr-3">
+                  <div className="bg-sky-200 p-2 rounded-lg mr-3">
                     <svg className="h-5 w-5 text-blue-500" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L19.2 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/>
                     </svg>
@@ -109,10 +109,10 @@ export default function EducationSection() {
             </Card>
 
             {/* Certifications */}
-            <Card className="bg-black border border-black">
+            <Card className="bg-sky-100 border border-sky-200">
               <CardContent className="p-8">
                 <h3 className="text-xl font-bold text-blue-500 mb-6 flex items-center">
-                  <div className="bg-black p-2 rounded-lg mr-3">
+                  <div className="bg-sky-200 p-2 rounded-lg mr-3">
                     <Award className="h-5 w-5 text-blue-500" />
                   </div>
                   Certifications
@@ -132,7 +132,7 @@ export default function EducationSection() {
 
         {/* Achievements */}
         <div className="mt-12">
-          <Card className="bg-black border border-black">
+          <Card className="bg-sky-100 border border-sky-200">
             <CardContent className="p-8">
               <h3 className="text-xl font-bold text-blue-500 mb-6 text-center">Achievements & Activities</h3>
               <div className="grid md:grid-cols-3 gap-6">
@@ -140,7 +140,7 @@ export default function EducationSection() {
                   const IconComponent = achievement.icon;
                   return (
                     <div key={index} className="text-center">
-                      <div className="bg-black w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                      <div className="bg-sky-200 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                         <IconComponent className="h-8 w-8 text-blue-500" />
                       </div>
                       <h4 className="font-semibold text-blue-500 mb-1">{achievement.title}</h4>

--- a/src/components/experience-section.tsx
+++ b/src/components/experience-section.tsx
@@ -80,7 +80,7 @@ export default function ExperienceSection() {
   return (
     <section
       id="experience"
-      className="py-20 bg-black"
+      className="py-20 bg-sky-50"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
@@ -98,10 +98,10 @@ export default function ExperienceSection() {
           <div className="space-y-12">
             {experiences.map((exp, index) => (
               <div key={exp.id} className={`relative flex items-center ${index % 2 === 1 ? 'md:flex-row-reverse' : ''}`}>
-                <div className="absolute left-6 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg bg-black"></div>
-                
+                <div className="absolute left-6 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg bg-sky-200"></div>
+
                 <div className={`ml-16 md:ml-0 md:w-1/2 ${index % 2 === 1 ? 'md:pl-12' : 'md:pr-12'}`}>
-                  <Card className="bg-black hover:shadow-xl border border-black transition-shadow">
+                  <Card className="bg-sky-100 hover:shadow-xl border border-sky-200 transition-shadow">
                     <CardContent className="p-6">
                       <div className="flex items-start justify-between mb-4">
                         <div>

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -114,7 +114,7 @@ export default function ProjectsSection() {
   return (
     <section
       id="projects"
-      className="py-20 bg-black"
+      className="py-20 bg-sky-50"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
@@ -145,7 +145,7 @@ export default function ProjectsSection() {
           {filteredProjects.map((project) => (
             <Card
               key={project.id}
-              className="bg-black border border-black overflow-hidden hover:shadow-xl transition-all duration-300 project-card"
+              className="bg-sky-100 border border-sky-200 overflow-hidden hover:shadow-xl transition-all duration-300 project-card"
             >
               <div className="relative">
                 <img

--- a/src/index.css
+++ b/src/index.css
@@ -121,17 +121,18 @@
 
 /* Gradient backgrounds */
 
+
 .bg-gradient-primary {
-  background: black;
+  background: linear-gradient(to bottom, white, #e0f2fe);
 }
 
 .bg-gradient-light {
-  background: black;
+  background: linear-gradient(to bottom, white, #e0f2fe);
 }
 
 /* Timeline styles */
 .timeline-line {
-  background: black;
+  background: #bae6fd;
 }
 
 /* Project card hover effects */


### PR DESCRIPTION
## Summary
- change experience section background to sky-50 and adjust timeline styles
- update project, contact and education sections to use light blue backgrounds
- revise gradients and timeline line colours

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844dd348b0883249d13d4699e0b30bb