### PR TITLE
Add animations and interactive project popup

### DIFF
--- a/src/components/experience-section.tsx
+++ b/src/components/experience-section.tsx
@@ -1,11 +1,14 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useEffect, useRef, useState } from "react";
 
 const experiences = [
   {
     id: 1,
     title: "PDC Careers Ambassador",
     company: "Brunel University London",
+    link: "https://www.brunel.ac.uk/pdc",
     period: "Nov 2023 – July 2025",
     description: "Supported Brunel’s Professional Career Development Centre (PDC) by assisting at university careers events, distributing materials, and engaging with students and staff.",
     technologies: ["Event Support", "Communication", "Teamwork"],
@@ -15,6 +18,7 @@ const experiences = [
     id: 2,
     title: "Systems Design Engineer Intern",
     company: "Brunel University London",
+    link: "https://www.brunel.ac.uk",
     period: "Feb 2024 – July 2024",
     description: "Contributing to systems and product design, technical reporting, and CAD/CAM tasks. Focused on sustainable engineering solutions and water management.",
     technologies: ["CAD", "Technical Reporting", "Sustainability"],
@@ -24,6 +28,7 @@ const experiences = [
     id: 3,
     title: "Junior Assistant Plumber",
     company: "JP Plumbing and Heating",
+    link: "#",
     period: "May 2023 – July 2023",
     description: "Assisted in plumbing installations and repairs, sourced parts, and provided on-site support for commercial and residential clients.",
     technologies: ["Pipefitting", "Customer Service", "Problem Solving"],
@@ -33,6 +38,7 @@ const experiences = [
     id: 4,
     title: "Sales Team Member / Stock Room Operative",
     company: "Clarks",
+    link: "https://www.clarks.com",
     period: "May 2022 – July 2022",
     description: "Provided retail support, assisted customers, managed stock, and maintained store organization.",
     technologies: ["Retail", "Sales", "Stock Management"],
@@ -42,6 +48,7 @@ const experiences = [
     id: 5,
     title: "Cleaning Operative",
     company: "Nviro Limited",
+    link: "https://www.nviro.co.uk",
     period: "Jan 2021 – Apr 2022",
     description: "Maintained cleanliness and hygiene standards in university buildings, ensuring a safe environment for staff and students.",
     technologies: ["Health & Safety", "Attention to Detail"],
@@ -51,6 +58,7 @@ const experiences = [
     id: 6,
     title: "Junior WordPress Developer",
     company: "Complex Creative",
+    link: "https://www.complexcreative.com",
     period: "Jul 2021 – Aug 2021",
     description: "Developed and maintained WordPress websites, collaborated with designers, and implemented new web features.",
     technologies: ["WordPress", "Web Design", "CMS"],
@@ -60,6 +68,7 @@ const experiences = [
     id: 7,
     title: "Food Bank Volunteer",
     company: "Masjid Ul Ibrahim",
+    link: "#",
     period: "Feb 2021 – Aug 2021",
     description: "Supported food distribution to local community members during the pandemic, offering direct client support.",
     technologies: ["Community Support", "Teamwork"],
@@ -69,6 +78,7 @@ const experiences = [
     id: 8,
     title: "IT Teaching Assistant",
     company: "Bonny Downs Community Association",
+    link: "https://www.bonnydowns.org",
     period: "Dec 2020 – Jan 2021",
     description: "Assisted teaching computer literacy to children and adults, providing technical support and guidance.",
     technologies: ["Teaching", "Technical Support"],
@@ -77,6 +87,24 @@ const experiences = [
 ];
 
 export default function ExperienceSection() {
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [visibleItems, setVisibleItems] = useState<number[]>([]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const i = Number(entry.target.getAttribute('data-index'));
+        if (entry.isIntersecting) {
+          setVisibleItems((v) => (v.includes(i) ? v : [...v, i]));
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.2 });
+
+    itemRefs.current.forEach((el) => el && observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <section
       id="experience"
@@ -97,8 +125,13 @@ export default function ExperienceSection() {
           {/* Experience Items */}
           <div className="space-y-12">
             {experiences.map((exp, index) => (
-              <div key={exp.id} className={`relative flex items-center ${index % 2 === 1 ? 'md:flex-row-reverse' : ''}`}>
-                <div className="absolute left-6 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg bg-sky-200"></div>
+              <div
+                key={exp.id}
+                data-index={index}
+                ref={(el) => (itemRefs.current[index] = el)}
+                className={`relative flex items-center ${index % 2 === 1 ? 'md:flex-row-reverse' : ''} ${visibleItems.includes(index) ? 'reveal-show' : 'reveal-hidden'}`}
+              >
+                <div className={`absolute left-6 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg bg-sky-200 ${visibleItems.includes(index) ? 'grow' : 'scale-50'}`}></div>
 
                 <div className={`ml-16 md:ml-0 md:w-1/2 ${index % 2 === 1 ? 'md:pl-12' : 'md:pr-12'}`}>
                   <Card className="bg-sky-100 hover:shadow-xl border border-sky-200 transition-shadow">
@@ -110,20 +143,24 @@ export default function ExperienceSection() {
                             {exp.company}
                           </p>
                         </div>
-                       <Badge variant={exp.current ? "default" : "primary"} className="text-sm">
-                    {exp.period}
-                  </Badge>
-                </div>
-                      
+                        <Badge variant={exp.current ? 'default' : 'primary'} className="text-sm">
+                          {exp.period}
+                        </Badge>
+                      </div>
+
                       <p className="text-blue-500 mb-4">{exp.description}</p>
-                      
-                      <div className="flex flex-wrap gap-2">
+
+                      <div className="flex flex-wrap gap-2 mb-4">
                         {exp.technologies.map((tech) => (
                           <Badge key={tech} variant="primary" className="text-xs">
                             {tech}
                           </Badge>
                         ))}
                       </div>
+
+                      <Button variant="outline" size="sm" asChild>
+                        <a href={exp.link} target="_blank" rel="noopener noreferrer">Learn More</a>
+                      </Button>
                     </CardContent>
                   </Card>
                 </div>

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -27,6 +27,11 @@ export default function HeroSection() {
       id="home"
       className="pt-16 min-h-screen flex items-center bg-black"
     >
+      <div className="absolute inset-0 pointer-events-none overflow-hidden">
+        <span className="shape w-24 h-24 rounded-full bg-teal-300 top-10 left-10 animate-shape1"></span>
+        <span className="shape w-16 h-16 bg-teal-300 top-1/2 right-20 rotate-45 animate-shape2"></span>
+        <span className="shape triangle w-20 h-20 bg-teal-300 bottom-10 left-1/3 animate-shape3"></span>
+      </div>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           <div className="space-y-8 animate-slide-up">

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { ExternalLink, Github } from "lucide-react";
 
 // You can replace the image URLs with real screenshots if you have them
@@ -105,6 +106,7 @@ const categories = [
 
 export default function ProjectsSection() {
   const [activeCategory, setActiveCategory] = useState("all");
+  const [selectedProject, setSelectedProject] = useState<typeof projects[number] | null>(null);
 
   const filteredProjects =
     activeCategory === "all"
@@ -149,7 +151,8 @@ export default function ProjectsSection() {
           {filteredProjects.map((project) => (
             <Card
               key={project.id}
-              className="bg-sky-100 border border-sky-200 overflow-hidden hover:shadow-xl transition-all duration-300 project-card"
+              onClick={() => setSelectedProject(project)}
+              className="bg-sky-100 border border-sky-200 overflow-hidden hover:shadow-xl transition-all duration-300 project-card cursor-pointer"
             >
               <div className="relative">
                 <img
@@ -198,6 +201,26 @@ export default function ProjectsSection() {
             </Card>
           ))}
         </div>
+        <Dialog open={!!selectedProject} onOpenChange={(o) => !o && setSelectedProject(null)}>
+          <DialogContent>
+            {selectedProject && (
+              <>
+                <DialogTitle>{selectedProject.title}</DialogTitle>
+                <p className="text-blue-500 mb-4">{selectedProject.description}</p>
+                <DialogFooter className="flex space-x-2">
+                  <Button asChild>
+                    <a href={selectedProject.githubUrl} target="_blank" rel="noopener noreferrer">Source Code</a>
+                  </Button>
+                  {selectedProject.liveUrl && (
+                    <Button variant="secondary" asChild>
+                      <a href={selectedProject.liveUrl} target="_blank" rel="noopener noreferrer">Live Demo</a>
+                    </Button>
+                  )}
+                </DialogFooter>
+              </>
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     </section>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -119,6 +119,80 @@
   animation: slide-up 0.8s ease-out;
 }
 
+@keyframes shape1 {
+  0%, 100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-30px) rotate(180deg);
+  }
+}
+
+@keyframes shape2 {
+  0%, 100% {
+    transform: translateX(0) rotate(0deg);
+  }
+  50% {
+    transform: translateX(30px) rotate(90deg);
+  }
+}
+
+@keyframes shape3 {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.4);
+  }
+}
+
+.shape {
+  position: absolute;
+  opacity: 0.15;
+}
+
+.triangle {
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+}
+
+.animate-shape1 {
+  animation: shape1 7s ease-in-out infinite;
+}
+
+.animate-shape2 {
+  animation: shape2 9s ease-in-out infinite;
+}
+
+.animate-shape3 {
+  animation: shape3 6s ease-in-out infinite;
+}
+
+@keyframes grow {
+  from {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.grow {
+  animation: grow 0.6s ease-out forwards;
+}
+
+.reveal-hidden {
+  opacity: 0;
+  transform: translateY(40px);
+}
+
+.reveal-show {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
 /* Gradient backgrounds */
 
 


### PR DESCRIPTION
## Summary
- animate random shapes in hero section
- reveal experience entries and enlarge timeline circles on scroll
- link experience cards to external resources
- open a popup on project click showing links to source and demo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684561de1cc08324b58e86bf60344823