### PR TITLE
Adjust UI elements

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Download, Mail } from "lucide-react";
 import { SiLinkedin, SiGithub } from "react-icons/si";
 
@@ -63,12 +64,14 @@ export default function ContactSection() {
                   </div>
               <h3 className="font-bold text-blue-500 mb-2">{method.title}</h3>
                   <p className="text-blue-500 mb-4">{method.value}</p>
-                  <a
-                    href={method.link}
-                    className="text-[lightblue] hover:text-blue-700 font-medium transition-colors"
-                  >
-                    {method.action}
-                  </a>
+                  <Badge variant="primary" className="cursor-pointer inline-block">
+                    <a
+                      href={method.link}
+                      className="text-white hover:text-white"
+                    >
+                      {method.action}
+                    </a>
+                  </Badge>
                 </CardContent>
               </Card>
             );

--- a/src/components/education-section.tsx
+++ b/src/components/education-section.tsx
@@ -88,7 +88,7 @@ export default function EducationSection() {
                     <h4 className="font-semibold text-blue-500 mb-2">Programming Languages</h4>
                     <div className="flex flex-wrap gap-2">
                       {skills.languages.map((lang) => (
-                        <Badge key={lang} variant="secondary" className="text-sm">
+                        <Badge key={lang} variant="primary" className="text-sm">
                           {lang}
                         </Badge>
                       ))}
@@ -98,7 +98,7 @@ export default function EducationSection() {
                     <h4 className="font-semibold text-blue-500 mb-2">Frameworks & Tools</h4>
                     <div className="flex flex-wrap gap-2">
                       {skills.frameworks.map((framework) => (
-                        <Badge key={framework} variant="secondary" className="text-sm">
+                        <Badge key={framework} variant="primary" className="text-sm">
                           {framework}
                         </Badge>
                       ))}

--- a/src/components/experience-section.tsx
+++ b/src/components/experience-section.tsx
@@ -99,7 +99,7 @@ export default function ExperienceSection() {
           observer.unobserve(entry.target);
         }
       });
-    }, { threshold: 0.2 });
+    }, { threshold: 0.5 });
 
     itemRefs.current.forEach((el) => el && observer.observe(el));
     return () => observer.disconnect();
@@ -131,7 +131,7 @@ export default function ExperienceSection() {
                 ref={(el) => (itemRefs.current[index] = el)}
                 className={`relative flex items-center ${index % 2 === 1 ? 'md:flex-row-reverse' : ''} ${visibleItems.includes(index) ? 'reveal-show' : 'reveal-hidden'}`}
               >
-                <div className={`absolute left-6 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg bg-sky-200 ${visibleItems.includes(index) ? 'grow' : 'scale-50'}`}></div>
+                <div className={`absolute left-8 md:left-1/2 transform md:-translate-x-1/2 w-4 h-4 rounded-full border-4 border-white shadow-lg bg-sky-200 ${visibleItems.includes(index) ? 'grow' : 'scale-50'}`}></div>
 
                 <div className={`ml-16 md:ml-0 md:w-1/2 ${index % 2 === 1 ? 'md:pl-12' : 'md:pr-12'}`}>
                   <Card className="bg-sky-100 hover:shadow-xl border border-sky-200 transition-shadow">

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -137,8 +137,8 @@ export default function ProjectsSection() {
               onClick={() => setActiveCategory(category.id)}
               className={
                 activeCategory === category.id
-                  ? "bg-teal-200 text-teal-800 border-teal-200 font-medium"
-                  : "border-teal-200 text-teal-800 font-medium"
+                  ? "bg-teal-200 text-teal-800 border-teal-200 font-medium transition-transform duration-300"
+                  : "text-teal-800 font-medium border-0 hover:bg-teal-200 hover:text-teal-800 hover:border hover:border-teal-200 hover:scale-105 transition-transform duration-300"
               }
             >
               {category.label}

--- a/src/index.css
+++ b/src/index.css
@@ -173,7 +173,7 @@
     opacity: 0;
   }
   to {
-    transform: scale(1);
+    transform: scale(1.5);
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- tweak project filter buttons to only show borders when active and zoom text on hover
- make timeline circles center-aligned and enlarge them when half scrolled into view
- use green badges for technical skills
- display contact actions as green badges

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684565a21e50832480701d836590fd67