### PR TITLE
Set dark theme default

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,9 @@
   </head>
   <body>
     <script>
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'dark') document.body.classList.add('dark');
+      const fallbackTheme = 'dark'
+      const theme = localStorage.getItem('theme') || fallbackTheme
+      if (theme === 'dark') document.body.classList.add('dark')
     </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -3,11 +3,13 @@ import { useEffect, useState } from "react";
 export type Theme = "light" | "dark";
 
 export function useTheme() {
+  const fallbackTheme: Theme = "dark";
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window !== "undefined") {
-      return (localStorage.getItem("theme") as Theme) || "dark";
+      const saved = localStorage.getItem("theme") as Theme | null;
+      return saved ?? fallbackTheme;
     }
-    return "dark";
+    return fallbackTheme;
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fallback to `dark` in index.html
- default to `dark` in the theme hook

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b3cd9097c8324b27a8d02399bba37